### PR TITLE
Replace Post Opportunity tab with modal dialog

### DIFF
--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -25,6 +25,7 @@ export function MultiSelect({
 }: MultiSelectProps) {
   const [open, setOpen] = React.useState(false)
   const dropdownRef = React.useRef<HTMLDivElement>(null)
+  const listboxId = React.useId()
 
   const handleUnselect = (item: string) => {
     onChange(selected.filter((i) => i !== item))
@@ -54,18 +55,19 @@ export function MultiSelect({
 
   return (
     <div className="relative w-full" ref={dropdownRef}>
-      <Button
-        type="button"
-        variant="outline"
+      <div
         role="combobox"
         aria-expanded={open}
+        aria-controls={listboxId}
+        aria-haspopup="listbox"
         className={cn(
-          "w-full justify-between text-left font-normal h-10 min-h-[2.5rem] px-3 py-2",
+          "flex w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background h-10 min-h-[2.5rem]",
+          "cursor-pointer hover:bg-accent hover:text-accent-foreground",
+          disabled && "cursor-not-allowed opacity-50",
           !selected.length && "text-muted-foreground",
           className
         )}
-        disabled={disabled}
-        onClick={() => setOpen(!open)}
+        onClick={() => !disabled && setOpen(!open)}
       >
         <div className="flex gap-1 flex-wrap max-w-full">
           {selected.length === 0 && (
@@ -78,17 +80,15 @@ export function MultiSelect({
                 variant="secondary"
                 key={item}
                 className="mr-1 mb-1 text-xs"
-                onClick={(e) => {
-                  e.preventDefault()
-                  e.stopPropagation()
-                  handleUnselect(item)
-                }}
               >
                 {option?.label}
                 <button
+                  type="button"
                   className="ml-1 ring-offset-background rounded-full outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
                   onKeyDown={(e) => {
                     if (e.key === "Enter") {
+                      e.preventDefault()
+                      e.stopPropagation()
                       handleUnselect(item)
                     }
                   }}
@@ -109,10 +109,14 @@ export function MultiSelect({
           })}
         </div>
         <ChevronDown className="h-4 w-4 shrink-0 opacity-50" />
-      </Button>
+      </div>
       
       {open && (
-        <div className="absolute z-50 w-full mt-1 bg-white border border-gray-200 rounded-md shadow-lg max-h-60 overflow-auto">
+        <div
+          id={listboxId}
+          role="listbox"
+          className="absolute z-50 w-full mt-1 bg-white border border-gray-200 rounded-md shadow-lg max-h-60 overflow-auto"
+        >
           {options.length === 0 ? (
             <div className="px-3 py-2 text-sm text-gray-500">No options available</div>
           ) : (


### PR DESCRIPTION
[Issue link](https://github.com/MoayadAlismail/ftn/issues/71)

## What changed
Replaced the two-tab layout (My Opportunities / Post Opportunity) with a cleaner single-page design. The opportunities list is now front and center, with a "+ Post New Opportunity" button that opens a modal for creating new posts.

## Why
- Users had to switch tabs just to see their opportunities, which was annoying
- The main content (opportunities list) should be immediately visible
- Follows common UX patterns.
- Better mobile experience with less navigation

## Technical details
- Removed Tabs components, converted to direct list view
- Added Dialog modal for opportunity creation form
- Fixed button-in-button hydration error in MultiSelect component
- All form validation and submission logic unchanged

## Screenshots
<img width="1919" height="847" alt="image" src="https://github.com/user-attachments/assets/0d0354dc-ae59-4105-a9d1-b6c5fb046920" />
<img width="1919" height="847" alt="image" src="https://github.com/user-attachments/assets/16e3c470-7dea-46bb-8b9c-dfd0c37aaf42" />

Closes #71 